### PR TITLE
zur Vermeidung von Hängern: CURLOPT_TTIMEOUT setzen

### DIFF
--- a/EG-PMS-LAN/module.php
+++ b/EG-PMS-LAN/module.php
@@ -235,6 +235,7 @@ class EGPMSLAN extends IPSModule
 		// configure
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 		curl_setopt($ch, CURLOPT_CONNECTTIMEOUT_MS, self::TIMEOUT);
+		curl_setopt($ch, CURLOPT_TTIMEOUT_MS, self::TIMEOUT);
 		//set the url, number of POST vars, POST data
 		curl_setopt($ch, CURLOPT_URL, $url);
 		//curl_setopt($ch, CURLOPT_USERAGENT, "IPSymcon");
@@ -266,6 +267,7 @@ class EGPMSLAN extends IPSModule
 		// configure
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 		curl_setopt($ch, CURLOPT_CONNECTTIMEOUT_MS, self::TIMEOUT);
+		curl_setopt($ch, CURLOPT_TTIMEOUT_MS, self::TIMEOUT);
 		//set the url, number of POST vars, POST data
 		curl_setopt($ch, CURLOPT_URL, $url . ($fields_string != '' ? '?' . $fields_string : ''));
 

--- a/EG-PMS-LAN/module.php
+++ b/EG-PMS-LAN/module.php
@@ -235,7 +235,7 @@ class EGPMSLAN extends IPSModule
 		// configure
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 		curl_setopt($ch, CURLOPT_CONNECTTIMEOUT_MS, self::TIMEOUT);
-		curl_setopt($ch, CURLOPT_TTIMEOUT_MS, self::TIMEOUT);
+		curl_setopt($ch, CURLOPT_TIMEOUT_MS, self::TIMEOUT);
 		//set the url, number of POST vars, POST data
 		curl_setopt($ch, CURLOPT_URL, $url);
 		//curl_setopt($ch, CURLOPT_USERAGENT, "IPSymcon");
@@ -267,7 +267,7 @@ class EGPMSLAN extends IPSModule
 		// configure
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 		curl_setopt($ch, CURLOPT_CONNECTTIMEOUT_MS, self::TIMEOUT);
-		curl_setopt($ch, CURLOPT_TTIMEOUT_MS, self::TIMEOUT);
+		curl_setopt($ch, CURLOPT_TIMEOUT_MS, self::TIMEOUT);
 		//set the url, number of POST vars, POST data
 		curl_setopt($ch, CURLOPT_URL, $url . ($fields_string != '' ? '?' . $fields_string : ''));
 

--- a/EG-PMS-LAN/module.php
+++ b/EG-PMS-LAN/module.php
@@ -235,7 +235,7 @@ class EGPMSLAN extends IPSModule
 		// configure
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 		curl_setopt($ch, CURLOPT_CONNECTTIMEOUT_MS, self::TIMEOUT);
-		curl_setopt($ch, CURLOPT_TIMEOUT_MS, self::TIMEOUT);
+		curl_setopt($ch, CURLOPT_TIMEOUT, 30);
 		//set the url, number of POST vars, POST data
 		curl_setopt($ch, CURLOPT_URL, $url);
 		//curl_setopt($ch, CURLOPT_USERAGENT, "IPSymcon");


### PR DESCRIPTION
Zur Vermeidung von Hängern bei der Kommunikation mit der EGPMS wird nun CURLOPT_TTIMEOUT auf 30s gesetzt