### PR TITLE
+ CURLOPT_TIMEOUT

### DIFF
--- a/EG-PMS-LAN/module.php
+++ b/EG-PMS-LAN/module.php
@@ -245,6 +245,7 @@ class EGPMSLAN extends IPSModule
 		// configure
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 		curl_setopt($ch, CURLOPT_CONNECTTIMEOUT_MS, self::TIMEOUT);
+		curl_setopt($ch, CURLOPT_TIMEOUT, 30);
 		//set the url, number of POST vars, POST data
 		curl_setopt($ch, CURLOPT_URL, $url);
 		//curl_setopt($ch, CURLOPT_USERAGENT, "IPSymcon");
@@ -276,6 +277,7 @@ class EGPMSLAN extends IPSModule
 		// configure
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 		curl_setopt($ch, CURLOPT_CONNECTTIMEOUT_MS, self::TIMEOUT);
+		curl_setopt($ch, CURLOPT_TIMEOUT, 30);
 		//set the url, number of POST vars, POST data
 		curl_setopt($ch, CURLOPT_URL, $url . ($fields_string != '' ? '?' . $fields_string : ''));
 

--- a/docs/de/README.md
+++ b/docs/de/README.md
@@ -14,6 +14,7 @@ Modul für IP-Symcon ab Version 4. Ermöglicht das Senden von Befehlen an die St
 4. [Funktionsreferenz](#4-funktionsreferenz)
 5. [Konfiguration](#5-konfiguartion)  
 6. [Anhang](#6-anhang)  
+7. [Versions-Historie](#7-versions-historie)
 
 ## 1. Funktionsumfang
 
@@ -133,3 +134,8 @@ Ausschalten des Steckdosenports $Port (1,2,3,4)
 #### EGPMSLAN:
 
 GUID: `{0113804D-EE66-48B9-8FF8-F81E4A5BAAEB}` 
+
+## 7. Versions-Historie
+
+- 1.1 @ 10.06.2019 17:57<br>
+  - HTTP-Requests wurden ohne TIMEOUT durchgeführt

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -14,6 +14,7 @@ Module for IP Symcon Version 4 or higher. Allows you to send commands to the Gem
 4. [Function reference](#4-functionreference)
 5. [Configuration](#5-configuration)
 6. [Annex](#6-annex)
+7. [Version-History](#7-version-history)
 
 ## 1. Features
 
@@ -134,3 +135,8 @@ Switching off the socket port $Port (1,2,3,4)
 #### EGPMSLAN:
 
 GUID: `{0113804D-EE66-48B9-8FF8-F81E4A5BAAEB}` 
+
+## 7. Version History
+
+- 1.1 @ 10.06.2019 17:57<br>
+  - HTTP requests were made without TIMEOUT

--- a/library.json
+++ b/library.json
@@ -3,7 +3,7 @@
   "author": "Fonzo",
   "name": "SymconEGPMSLAN",
   "url": "https://github.com/wolbolar/",
-  "version": "1.0",
-  "build": 2,
-  "date": 0
+  "version": "1.1",
+  "build": 0,
+  "date": 1560182255
 }


### PR DESCRIPTION
die http-Request waren ohne TIMEOIUT, daher bleiben die auch mal hängen und irgendwann ist Schluss ...

Das vorhandenen CURLOPT_CONNECTTIMEOUT_MS ist ja nur bis zur vollzogenen Verbindungsaufnahme zuständig, aber wenn die Steckdose nach dem Login nix mehr antwortet, gibt's kein Timeout